### PR TITLE
ci!: drop EOL Pythons 3.7-3.9, test on 3.10-3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.11", "3.10", "3.9", "3.8", "3.7"]
+        python-version: ["3.14", "3.13", "3.12", "3.11", "3.10"]
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v7
-      - name: Set up Python 3.11
+      - name: Set up Python 3.14
         uses: actions/setup-python@v7
         with:
           python-version: "3.14"
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.11", "3.10", "3.9", "3.8", "3.7"]
+        python-version: ["3.14", "3.13", "3.12", "3.11", "3.10"]
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.11", "3.10", "3.9", "3.8", "3.7"]
+        python-version: ["3.14", "3.13", "3.12", "3.11", "3.10"]
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.11", "3.10", "3.9", "3.8"]
+        python-version: ["3.14", "3.13", "3.12", "3.11", "3.10"]
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -163,4 +163,7 @@ cython_debug/
 # vscode settings
 /.vscode/
 
+# Claude Code local settings
+/.claude/
+
 /html_docs/

--- a/hitchhiker/cli/cli.py
+++ b/hitchhiker/cli/cli.py
@@ -1,4 +1,4 @@
-import sys
+import importlib.metadata
 
 import click
 
@@ -7,17 +7,10 @@ from hitchhiker.config.config import ConfigManager
 from .auth import commands as auth
 from .modules import commands as modules
 
-if sys.version_info[1] > 7:
-    try:
-        import importlib.metadata
-
-        _HITCHHIKER_VERSION = importlib.metadata.version("hitchhiker")
-    except importlib.metadata.PackageNotFoundError:
-        _HITCHHIKER_VERSION = "unknown"
-else:
-    import pkg_resources
-
-    _HITCHHIKER_VERSION = pkg_resources.get_distribution("hitchhiker").version
+try:
+    _HITCHHIKER_VERSION = importlib.metadata.version("hitchhiker")
+except importlib.metadata.PackageNotFoundError:
+    _HITCHHIKER_VERSION = "unknown"
 
 
 @click.group()

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     name="hitchhiker",
     version=_hitchhiker_version,
     description="",
-    python_requires=">=3.7",
+    python_requires=">=3.10",
     install_requires=[
         "click>=8,<9",
         "tomlkit>=0.12.3,<1",


### PR DESCRIPTION
## Summary
- Drop EOL Python 3.7-3.9 from the build matrix; test/type-check/lint on 3.10-3.14
- Bump `python_requires` to `>=3.10` (**BREAKING CHANGE** → semantic-release will cut 2.0.0)
- Remove the dead Python 3.7 `pkg_resources` fallback in `cli.py`
- Fix coverage job step name (said 3.11, uses 3.14)
- Ignore local `.claude/` directory

## Why
The old matrix blocks the open Renovate PRs: pytest 9 (#64) and google-cloud-storage 3 (#63) require newer Pythons, and setup-python has no 3.7 build for ubuntu-24.04 runners (#65). After this merges, those PRs need a rebase and should pass.

## Test plan
- [x] CI green on all 21 jobs (run 32653426045)
- [x] Locally: 34/34 pytest, mypy --strict clean, make lint 10.00/10 (Python 3.12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)